### PR TITLE
fix: suppress harmless PDO packets-out-of-order warning

### DIFF
--- a/lib/Zend/Db/Statement/Pdo.php
+++ b/lib/Zend/Db/Statement/Pdo.php
@@ -224,10 +224,19 @@ class Zend_Db_Statement_Pdo extends Zend_Db_Statement implements IteratorAggrega
     public function _execute(array $params = null)
     {
         try {
+            // PDO emits a non-actionable PHP Warning ("Packets out of order …")
+            // before throwing PDOException when MySQL has dropped a stale
+            // pooled connection (wait_timeout). The exception path below is
+            // already handled by Varien_Db_Adapter_Pdo_Mysql::raw_query()
+            // which detects "MySQL server has gone away" (errno 2006/2013)
+            // and reconnects transparently — so the warning is just noise
+            // that pollutes var/log/system.log every cron tick. Suppress
+            // with @ so we keep the meaningful exception flow intact while
+            // muting the scary-looking but harmless warning.
             if ($params !== null) {
-                return $this->_stmt->execute($params);
+                return @$this->_stmt->execute($params);
             } else {
-                return $this->_stmt->execute();
+                return @$this->_stmt->execute();
             }
         } catch (PDOException $e) {
             #require_once 'Zend/Db/Statement/Exception.php';


### PR DESCRIPTION
## Summary
Mutes the noisy PHP warning emitted when MySQL's \`wait_timeout\` kills an idle pooled connection — without changing how the actual reconnect logic behaves.

## Symptom
\`\`\`
ERR (3): Warning: Packets out of order. Expected 1 received 0. Packet size=145
        in /usr/htdocs/.../lib/Zend/Db/Statement/Pdo.php on line 228
WARN (4): MySQL connection lost, attempting to reconnect:
        SQLSTATE[HY000]: General error: 2006 MySQL server has gone away,
        query was: SELECT 1
DEBUG (7): MySQL reconnection successful
\`\`\`

Long-running PHP processes (cron, RabbitMQ workers, persistent FPM workers) periodically tick a \`SELECT 1\` ping after MySQL has already closed the idle connection. The PDO driver emits a Warning before throwing PDOException. Varien_Db_Adapter_Pdo_Mysql already catches \`2006\`/\`2013\` and reconnects — only the pre-throw warning makes it to the log.

## Fix
Wrap the two \`_stmt->execute()\` calls inside \`Zend_Db_Statement_Pdo::_execute\` with \`@\` so the warning is suppressed but the PDOException still propagates and is caught by the existing reconnect handler.

No behavioural change. Just stops every cron tick logging a scary-looking ERR.

## Caveat
Modifying \`lib/Zend/Db/Statement/Pdo.php\` (Zend Framework 1 in OpenMage's lib/) — needs to be re-applied after any future OpenMage upgrade.